### PR TITLE
Use luacheck to ensure quality of code in the build, exit on error

### DIFF
--- a/firmware-release-builder.sh
+++ b/firmware-release-builder.sh
@@ -235,6 +235,9 @@ git checkout ${FRB_GIT_BRANCH}
 git pull
 
 cd $WORKSPACE
+to_output "Running luacheck linter"
+luacheck package scripts targets || exit 1
+
 to_output "Update OpenWrt"
 make update
 check_last_exitcode


### PR DESCRIPTION
The gluon project is starting to embrace linters including luacheck. When raising Code towards the gluon project, it must be ensured the proper standards are met.

Let's execute luacheck as part of our builds too.